### PR TITLE
Update actions/checkout and actions/upload-artifact to v4 since v3 is…

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -24,7 +24,7 @@ jobs:
           ./build.sh
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: buildroot-images
           path: buildroot/output/images/sdcard.img


### PR DESCRIPTION
… deprecated

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/